### PR TITLE
Enable httplib debug logging w/o messing up modular input event stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+*.pyc
 implementations/snmp/bin/mibs/*.py
-implementations/snmp/bin/mibs/*.pyc
 temp_build/


### PR DESCRIPTION
Hey Damien,

Some hack-and-slack work to enable turning on httplib debugging.   This was helpful to me in debugging some OAuth2 issues, so I thought I'd pass it along.  Basically, I moved all of the modinput's output-to-splunk to an alternate file object so that I could reassign sys.stdout to be the same as sys.stderr.   It's a little hacky but it deals with the fact that httplib does some dirty stuff with its debug logging.